### PR TITLE
Use const variables for key codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ If you [register for Hacktoberfest](https://hacktoberfest.digitalocean.com/sign_
  - WicoGoHome ([wicogohome](https://github.com/wicogohome))
  - WooodHead ([WooodHead](https://github.com/WooodHead))
  - iojw ([iojw](https://github.com/iojw))
+ - dl471 ([dl471](https://github.com/dl471))

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -18,6 +18,13 @@ var modalMessage = '';
 var modal = document.getElementById("modal");
 var span = document.getElementsByClassName("close")[0];
 
+// Key Codes for reading user input
+const SPACE = 32;
+const LEFT = 37;
+const UP = 38;
+const RIGHT = 39;
+const DOWN = 40;
+
 function showModal(message) {
 	addModalMessage(message);
 	modal.style.display = "block";
@@ -290,23 +297,23 @@ function showGame() {
 		e = e || window.event;
 		var key = parseInt(e.keyCode);
 		switch (key) {
-			case 38:
+			case UP:
 				snek.changeDir('U');
 				e.preventDefault();
 				break;
-			case 39:
+			case RIGHT:
 				snek.changeDir('R');
 				e.preventDefault();
 				break;
-			case 40:
+			case DOWN:
 				snek.changeDir('D');
 				e.preventDefault();
 				break;
-			case 37:
+			case LEFT:
 				snek.changeDir('L');
 				e.preventDefault();
 				break;
-			case 32:
+			case SPACE:
 				var x = document.activeElement;
 				if (x.id != 'username'){
 					e.preventDefault();


### PR DESCRIPTION
I changed the numbers in the user input loop to use named constants instead of raw key numbers since I think it makes the intention of the code a bit more explicit. That said it's still clear the numbers were supposed to be key codes so it might be more of a personal preference.