### PR TITLE
Add line-height property to #out in style.css

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -75,6 +75,7 @@ h1 {
     margin: 30px;
     padding: 20px;
     border-radius: 5px;
+    line-height: 60px;
     color: #057356;
     background:rgba(255,129,0,0.9);
     text-transform: uppercase;


### PR DESCRIPTION
The "#out" element's text will overlap if the message is more than a few words long and the player is using a viewport that is less than ~850px wide. I just added a "line-height: 60px" property to index.css.