### PR TITLE
Fix overlap of out-text element

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -81,6 +81,7 @@ h1 {
     font-family: 'Overpass Mono', monospace;
     font-size: larger;
     font-weight: bold;
+    line-height: 60px;
 }
 
 #game, #getname, .hidden {


### PR DESCRIPTION
The "#out" element's text overlaps when the viewport is too small, so I added "line-height: 60px" to "#out" in index.css to prevent overlap.