### PR TITLE
Fix text overlap in out-text element

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -72,6 +72,8 @@ h1 {
 }
 
 #out {
+    display: flex;
+    justify-content: center;
     margin: 30px;
     padding: 20px;
     border-radius: 5px;


### PR DESCRIPTION
Added "display: flex" and "justify-content: center" to "#out" in "style/index.css" to prevent text overlap.